### PR TITLE
kono-api (fix #34)

### DIFF
--- a/kono-api/.babelrc
+++ b/kono-api/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-env"
+    ]
+}

--- a/kono-api/package-lock.json
+++ b/kono-api/package-lock.json
@@ -1086,6 +1086,12 @@
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -1127,6 +1133,15 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -1194,6 +1209,12 @@
           }
         }
       }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1392,6 +1413,12 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -1565,6 +1592,20 @@
       "integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1575,6 +1616,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.8",
@@ -1922,6 +1969,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -1996,6 +2052,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -2161,6 +2223,12 @@
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -2478,6 +2546,23 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "flush-write-stream": {
@@ -3109,6 +3194,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3206,6 +3297,12 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3278,6 +3375,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -3640,6 +3743,16 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3817,6 +3930,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4057,6 +4179,105 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.1.tgz",
+      "integrity": "sha512-VCcWkLHwk79NYQc8cxhkmI8IigTIhsCwZ6RTxQsqK6go4UvEhzJkYuHm8B2YtlSxcYq2fY+ucr4JBwoD6ci80A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "node-environment-flags": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+          "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+          "dev": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3",
+            "semver": "^5.7.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
       }
     },
     "move-concurrently": {
@@ -4475,6 +4696,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -5201,6 +5428,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "sqlstring": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
@@ -5332,6 +5565,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -5549,6 +5788,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {
@@ -5906,6 +6151,42 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -5977,6 +6258,37 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
       }
     }
   }

--- a/kono-api/package-lock.json
+++ b/kono-api/package-lock.json
@@ -732,6 +732,22 @@
         "regexpu-core": "^4.6.0"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.2.tgz",
@@ -857,6 +873,34 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@types/chai": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
+      "integrity": "sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==",
+      "dev": true
+    },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
+      "dev": true
+    },
+    "@types/superagent": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
+      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
       }
     },
     "@webassemblyjs/ast": {
@@ -1228,6 +1272,12 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1594,6 +1644,30 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
+    "chai-http": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.3.0.tgz",
+      "integrity": "sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "4",
+        "@types/superagent": "^3.8.3",
+        "cookiejar": "^2.1.1",
+        "is-ip": "^2.0.0",
+        "methods": "^1.1.2",
+        "qs": "^6.5.1",
+        "superagent": "^3.7.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1715,6 +1789,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -1806,6 +1889,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -2015,6 +2104,12 @@
           }
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2363,6 +2458,12 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -2567,6 +2668,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
       "dev": true
     },
     "forwarded": {
@@ -3492,6 +3610,12 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -3608,6 +3732,15 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.0.0"
       }
     },
     "is-number": {
@@ -4893,8 +5026,7 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -5517,6 +5649,41 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/kono-api/package-lock.json
+++ b/kono-api/package-lock.json
@@ -1234,18 +1234,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "babel-loader": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-      "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "^2.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "pify": "^4.0.1"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
@@ -3710,27 +3698,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "jest-worker": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-      "dev": true,
-      "requires": {
-        "merge-stream": "^2.0.0",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "js-levenshtein": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -4039,12 +4006,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -5127,16 +5088,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "schema-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.4.0.tgz",
-      "integrity": "sha512-VJEKOvjynJweKWFgxaikuP22zl9JwvmylH/cW1dIKZyp3DS1adBGaYPtZ6CdBSxtfP0LwQY1gNA4rIMJsnammQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1"
-      }
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5168,12 +5119,6 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
-    },
-    "serialize-javascript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.0.tgz",
-      "integrity": "sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==",
-      "dev": true
     },
     "serve-static": {
       "version": "1.14.1",
@@ -5599,99 +5544,6 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "terser-webpack-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.1.0.tgz",
-      "integrity": "sha512-sZs43FVvNTqHp5hTkTSIC3XKB7rEC2FCbx9Uv0rM7D4iJsbTA1Q84tiaRYSSKSojBe6LCONX44RF73AEHGasvw==",
-      "dev": true,
-      "requires": {
-        "cacache": "^12.0.3",
-        "find-cache-dir": "^3.0.0",
-        "jest-worker": "^24.9.0",
-        "schema-utils": "^2.2.0",
-        "serialize-javascript": "^2.1.0",
-        "source-map": "^0.6.1",
-        "terser": "^4.3.1",
-        "webpack-sources": "^1.4.3"
-      },
-      "dependencies": {
-        "find-cache-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.0.0.tgz",
-          "integrity": "sha512-t7ulV1fmbxh5G9l/492O1p5+EBbr3uwpt6odhFTMc+nWyhmbloe+ja9BZ8pIBtqFWhOmCWVjx+pTW4zDkFoclw==",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^3.0.0",
-            "pkg-dir": "^4.1.0"
-          }
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "make-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/kono-api/package.json
+++ b/kono-api/package.json
@@ -4,7 +4,9 @@
   "description": "API Server providing apis for the front-end web service. - Express.js",
   "main": "index.js",
   "scripts": {
-    "start:dev": "NODE_ENV=development nodemon --delay 1500ms -L --watch src/ --exec babel-node --plugins @babel/plugin-proposal-object-rest-spread --presets @babel/preset-env src/",
+    "start:dev": "NODE_ENV=development nodemon -L --watch src/ --exec babel-node src/index.js",
+    "test:dev": "NODE_ENV=development node_modules/.bin/mocha --require @babel/register src/test/test.js",
+    "test:production": "NODE_ENV=production node_modules/.bin/mocha --require @babel/register src/test/test.js",
     "build": "webpack --config webpack.config.js",
     "serve": "NODE_ENV=production node dist/bundle.js"
   },
@@ -21,12 +23,10 @@
     "@babel/cli": "^7.6.2",
     "@babel/core": "^7.6.2",
     "@babel/node": "^7.6.2",
-    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
-    "babel-loader": "^8.0.6",
+    "@babel/register": "^7.6.2",
     "chai": "^4.2.0",
     "mocha": "^6.2.1",
-    "terser-webpack-plugin": "^2.1.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"
   }

--- a/kono-api/package.json
+++ b/kono-api/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@babel/polyfill": "^7.6.0",
     "cookie-parser": "^1.4.4",
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
@@ -26,6 +27,8 @@
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "chai-http": "^4.3.0",
     "mocha": "^6.2.1",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"

--- a/kono-api/package.json
+++ b/kono-api/package.json
@@ -24,6 +24,8 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
     "babel-loader": "^8.0.6",
+    "chai": "^4.2.0",
+    "mocha": "^6.2.1",
     "terser-webpack-plugin": "^2.1.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"

--- a/kono-api/src/api/v1/post/post.test.js
+++ b/kono-api/src/api/v1/post/post.test.js
@@ -1,11 +1,179 @@
-import { request,  assert } from 'chai';
+import { request, expect } from 'chai';
+import { apiURL } from '../../../test/common';
 
 describe('Testing GET /api/v1/post ...', () => {
 
-    it('This test set is not broken.', () => {
-        assert(true, true, 'true should equal true');
+    it('General case 1', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'notice',
+                start_index: 0,
+                max_size: 5
+            })
+            .then(res => {
+                expect(res).status(200);
+                expect(res.body).to.have.keys(['size', 'posts']);
+                const { size, posts } = res.body;
+                expect(size).to.be.a('number');
+                expect(size).to.be.least(0);
+                expect(posts).to.be.a('array');
+                expect(posts).to.have.lengthOf.most(5);
+                posts.forEach(post => {
+                    expect(post).to.have.keys(['sid', 'title_kr', 'title_en', 'created_time', 'type']);
+                    const { sid, type, title_kr, title_en, created_time } = post;
+                    expect(sid).to.be.a('number');
+                    expect(sid).to.be.least(0);
+                    expect(type).to.equal('notice');
+                    expect(title_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(title_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(created_time).to.satisfy(e => !isNaN(Date.parse(e)));
+                });
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
     });
-    
-    
+
+    it('General case 2', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                start_index: 0,
+                max_size: 2
+            })
+            .then(res => {
+                expect(res).status(200);
+                expect(res.body).to.have.keys(['size', 'posts']);
+                const { size, posts } = res.body;
+                expect(size).to.be.a('number');
+                expect(size).to.be.least(0);
+                expect(posts).to.be.a('array');
+                expect(posts).to.have.lengthOf.most(2);
+                posts.forEach(post => {
+                    expect(post).to.have.keys(['sid', 'title_kr', 'title_en', 'created_time', 'type']);
+                    const { sid, type, title_kr, title_en, created_time } = post;
+                    expect(sid).to.be.a('number');
+                    expect(sid).to.be.least(0);
+                    expect(type).to.be.oneOf(['notice', 'lostfound']);
+                    expect(title_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(title_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(created_time).to.satisfy(e => !isNaN(Date.parse(e)));
+                });
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
+
+    it('Invalid query "filter_type"', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'foo',
+                start_index: 0,
+                max_size: 5
+            })
+            .then(res => {
+                expect(res).status(400);
+                expect(res.body).to.have.key('msg');
+                expect(res.body.msg).to.equal('invalid filter_type');
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
+
+    it('Invalid query "start_index"', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'notice',
+                start_index: -5,
+                max_size: 5
+            })
+            .then(res => {
+                expect(res).status(400);
+                expect(res.body).to.have.key('msg');
+                expect(res.body.msg).to.equal('invalid start_index');
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
+
+    it('Invalid query "max_size" (below 0)', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'notice',
+                start_index: 0,
+                max_size: -3
+            })
+            .then(res => {
+                expect(res).status(400);
+                expect(res.body).to.have.key('msg');
+                expect(res.body.msg).to.equal('invalid max_size');
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
+
+    it('Invalid query "max_size" (over 64)', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'notice',
+                start_index: 0,
+                max_size: 237
+            })
+            .then(res => {
+                expect(res).status(400);
+                expect(res.body).to.have.key('msg');
+                expect(res.body.msg).to.equal('invalid max_size');
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
+
+    it('Missing query "max_size"', (done) => {
+
+        request(apiURL)
+            .get('/api/v1/post')
+            .query({
+                filter_type: 'notice',
+                start_index: 0
+            })
+            .then(res => {
+                expect(res).status(400);
+                expect(res.body).to.have.key('msg');
+                expect(res.body.msg).to.equal('max_size required');
+                done();
+            })
+            .catch(err => {
+                done(err);
+            });
+
+    });
 
 });

--- a/kono-api/src/api/v1/post/post.test.js
+++ b/kono-api/src/api/v1/post/post.test.js
@@ -1,0 +1,11 @@
+import { request,  assert } from 'chai';
+
+describe('Testing GET /api/v1/post ...', () => {
+
+    it('This test set is not broken.', () => {
+        assert(true, true, 'true should equal true');
+    });
+    
+    
+
+});

--- a/kono-api/src/api/v1/post/post.test.js
+++ b/kono-api/src/api/v1/post/post.test.js
@@ -3,15 +3,11 @@ import { apiURL } from '../../../test/common';
 
 describe('Testing GET /api/v1/post ...', () => {
 
-    it('General case 1', (done) => {
-
+    const testGeneralCase = (query) => (done) => {
+        const { max_size } = query;
         request(apiURL)
             .get('/api/v1/post')
-            .query({
-                filter_type: 'notice',
-                start_index: 0,
-                max_size: 5
-            })
+            .query(query)
             .then(res => {
                 expect(res).status(200);
                 expect(res.body).to.have.keys(['size', 'posts']);
@@ -19,41 +15,7 @@ describe('Testing GET /api/v1/post ...', () => {
                 expect(size).to.be.a('number');
                 expect(size).to.be.least(0);
                 expect(posts).to.be.a('array');
-                expect(posts).to.have.lengthOf.most(5);
-                posts.forEach(post => {
-                    expect(post).to.have.keys(['sid', 'title_kr', 'title_en', 'created_time', 'type']);
-                    const { sid, type, title_kr, title_en, created_time } = post;
-                    expect(sid).to.be.a('number');
-                    expect(sid).to.be.least(0);
-                    expect(type).to.equal('notice');
-                    expect(title_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
-                    expect(title_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
-                    expect(created_time).to.satisfy(e => !isNaN(Date.parse(e)));
-                });
-                done();
-            })
-            .catch(err => {
-                done(err);
-            });
-
-    });
-
-    it('General case 2', (done) => {
-
-        request(apiURL)
-            .get('/api/v1/post')
-            .query({
-                start_index: 0,
-                max_size: 2
-            })
-            .then(res => {
-                expect(res).status(200);
-                expect(res.body).to.have.keys(['size', 'posts']);
-                const { size, posts } = res.body;
-                expect(size).to.be.a('number');
-                expect(size).to.be.least(0);
-                expect(posts).to.be.a('array');
-                expect(posts).to.have.lengthOf.most(2);
+                expect(posts).to.have.lengthOf.most(max_size);
                 posts.forEach(post => {
                     expect(post).to.have.keys(['sid', 'title_kr', 'title_en', 'created_time', 'type']);
                     const { sid, type, title_kr, title_en, created_time } = post;
@@ -69,111 +31,178 @@ describe('Testing GET /api/v1/post ...', () => {
             .catch(err => {
                 done(err);
             });
+    };
 
-    });
-
-    it('Invalid query "filter_type"', (done) => {
-
+    const testFilter = (query) => (done) => {
+        const { filter_type, max_size } = query;
         request(apiURL)
             .get('/api/v1/post')
-            .query({
-                filter_type: 'foo',
-                start_index: 0,
-                max_size: 5
-            })
+            .query(query)
             .then(res => {
-                expect(res).status(400);
-                expect(res.body).to.have.key('msg');
-                expect(res.body.msg).to.equal('invalid filter_type');
+                expect(res).status(200);
+                expect(res.body).to.have.keys(['size', 'posts']);
+                const { size, posts } = res.body;
+                expect(size).to.be.a('number');
+                expect(size).to.be.least(0);
+                expect(posts).to.be.a('array');
+                expect(posts).to.have.lengthOf.most(max_size);
+                posts.forEach(post => {
+                    expect(post).to.have.keys(['sid', 'title_kr', 'title_en', 'created_time', 'type']);
+                    const { sid, type, title_kr, title_en, created_time } = post;
+                    expect(sid).to.be.a('number');
+                    expect(sid).to.be.least(0);
+                    expect(type).to.equal(filter_type);
+                    expect(title_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(title_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(created_time).to.satisfy(e => !isNaN(Date.parse(e)));
+                });
                 done();
             })
             .catch(err => {
                 done(err);
             });
+    };
 
-    });
-
-    it('Invalid query "start_index"', (done) => {
-
+    const testInvalidQuery = (query, invalidQuery) => (done) => {
         request(apiURL)
             .get('/api/v1/post')
-            .query({
-                filter_type: 'notice',
-                start_index: -5,
-                max_size: 5
-            })
+            .query(query)
             .then(res => {
                 expect(res).status(400);
                 expect(res.body).to.have.key('msg');
-                expect(res.body.msg).to.equal('invalid start_index');
+                expect(res.body.msg).to.equal(`invalid ${invalidQuery}`);
                 done();
             })
             .catch(err => {
                 done(err);
             });
+    };
 
-    });
-
-    it('Invalid query "max_size" (below 0)', (done) => {
-
+    const testRequiredQuery = (query, requiredQuery) => (done) => {
         request(apiURL)
             .get('/api/v1/post')
-            .query({
-                filter_type: 'notice',
-                start_index: 0,
-                max_size: -3
-            })
+            .query(query)
             .then(res => {
                 expect(res).status(400);
                 expect(res.body).to.have.key('msg');
-                expect(res.body.msg).to.equal('invalid max_size');
+                expect(res.body.msg).to.equal(`${requiredQuery} required`);
                 done();
             })
             .catch(err => {
                 done(err);
             });
+    };
 
+    describe('General cases.', () => {
+        it('Test case 1', testGeneralCase({
+            start_index: 0,
+            max_size: 5
+        }));
+        it('Test case 2', testGeneralCase({
+            max_size: 2
+        }));
+        it('Test case 3', testGeneralCase({
+            max_size: 6
+        }));
     });
 
-    it('Invalid query "max_size" (over 64)', (done) => {
+    describe('Testing filter_type.', () => {
+        it('Filter by notice', testFilter({
+            filter_type: 'notice',
+            max_size: 64
+        }));
+        it('Filter by lostfound', testFilter({
+            filter_type: 'lostfound',
+            max_size: 64
+        }));
+    });
 
+    describe('Error handling.', () => {
+        it('Invalid query "filter_type"', testInvalidQuery({
+            filter_type: 'foo',
+            start_index: 0,
+            max_size: 64
+        }, 'filter_type'));
+        it('Invalid query "start_index"', testInvalidQuery({
+            filter_type: 'lostfound',
+            start_index: -5,
+            max_size: 64
+        }, 'start_index'));
+        it('Invalid query "max_size" (below 0)', testInvalidQuery({
+            filter_type: 'notice',
+            start_index: 3,
+            max_size: -1
+        }, 'max_size'));
+        it('Invalid query "max_size" (over 64)', testInvalidQuery({
+            filter_type: 'notice',
+            start_index: 3,
+            max_size: 65
+        }, 'max_size')); 
+        it('Missing query "max_size"', testRequiredQuery({
+            filter_type: 'lostfound',
+            start_index: 1
+        }, 'max_size'));
+    });
+
+});
+
+describe('Testing GET /api/v1/post/:sid ...', () => {
+
+    const testGeneralCase = (sid) => (done) => {
         request(apiURL)
-            .get('/api/v1/post')
-            .query({
-                filter_type: 'notice',
-                start_index: 0,
-                max_size: 237
-            })
+            .get(`/api/v1/post/${sid}`)
             .then(res => {
-                expect(res).status(400);
-                expect(res.body).to.have.key('msg');
-                expect(res.body.msg).to.equal('invalid max_size');
+                expect(res.status).to.be.oneOf([200, 404]);
+                if (res.status === 200) {
+                    expect(res.body).to.have.keys(['sid', 'type', 'title_kr', 'title_en', 'created_time', 'content_kr', 'content_en', 'content_img']);
+                    const { sid, type, title_kr, title_en, created_time, content_kr, content_en, content_img } = res.body;
+                    expect(sid).to.equal(sid);
+                    expect(type).to.be.oneOf(['notice', 'lostfound']);
+                    expect(title_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(title_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(created_time).to.satisfy(e => !isNaN(Date.parse(e)));
+                    expect(content_kr).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(content_en).to.satisfy(e => (e === null) || (typeof e === 'string'));
+                    expect(content_img).to.be.a('array');
+                    content_img.forEach(img => {
+                        expect(img).to.be.a('string');
+                    });
+                }
+                else if (res.status === 404) {
+                    expect(res.body).to.have.key('msg');
+                    expect(res.body.msg).to.equal('post does not exist');
+                }
                 done();
             })
             .catch(err => {
                 done(err);
             });
+    };
 
-    });
-
-    it('Missing query "max_size"', (done) => {
-
+    const testInvalidSID = (sid) => (done) => {
         request(apiURL)
-            .get('/api/v1/post')
-            .query({
-                filter_type: 'notice',
-                start_index: 0
-            })
+            .get(`/api/v1/post/${sid}`)
             .then(res => {
-                expect(res).status(400);
+                expect(res.status).to.equal(400);
                 expect(res.body).to.have.key('msg');
-                expect(res.body.msg).to.equal('max_size required');
+                expect(res.body.msg).to.equal('invalid sid');
                 done();
             })
             .catch(err => {
                 done(err);
             });
+    }
 
+    describe('General cases.', () => {
+        it('Test case 1', testGeneralCase(7));
+        it('Test case 2', testGeneralCase(2));
+        it('Test case 3', testGeneralCase(11));
+        it('Test case 4', testGeneralCase(16));
+    });
+
+    describe('Error handling.', () => {
+        it('Invalid sid (3.6)', testInvalidSID(3.6));
+        it('Invalid sid (-5)', testInvalidSID(-5));
     });
 
 });

--- a/kono-api/src/index.js
+++ b/kono-api/src/index.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill';
+
 import dotenv from 'dotenv';
 import express from 'express';
 import bodyParser from 'body-parser';

--- a/kono-api/src/routes.test.js
+++ b/kono-api/src/routes.test.js
@@ -1,0 +1,19 @@
+import { request, assert } from 'chai';
+import { apiURL, nodeEnv } from './test/common';
+
+describe('Testing GET / ...', () => {
+
+    it('Server is alive and responding', (done) => {
+        request(apiURL)
+            .get('/')
+            .then(res => {
+                assert.equal(res.status, 200);
+                assert.equal(res.text, `kono-api ${nodeEnv} server`);
+                done();
+            })
+            .catch(err => {
+                done(err);
+            })
+    });
+
+});

--- a/kono-api/src/test/common.js
+++ b/kono-api/src/test/common.js
@@ -1,0 +1,16 @@
+const {
+    DEV_HOST,
+    PROD_HOST,
+    DEV_PORT,
+    PROD_PORT,
+    NODE_ENV
+} = process.env;
+
+export const nodeEnv = NODE_ENV;
+export const host = NODE_ENV === 'production' ? 
+    PROD_HOST : 
+    DEV_HOST;
+export const port = NODE_ENV === 'production' ? 
+    PROD_PORT : 
+    DEV_PORT;
+export const apiURL = `http://${host}:${port}`;

--- a/kono-api/src/test/test.js
+++ b/kono-api/src/test/test.js
@@ -1,7 +1,15 @@
-import { assert } from 'chai';
+import '@babel/polyfill';
+
+import * as chai from 'chai';
+import chaiHttp from 'chai-http';
+import chaiAsPromised from 'chai-as-promised';
 import dotenv from 'dotenv';
 
 dotenv.config();
+
+/* Add plugins to chai. */
+chai.use(chaiHttp);
+chai.use(chaiAsPromised);
 
 function importTest(path) {
     describe(`Running unit tests in ${path}`, () => {
@@ -15,9 +23,7 @@ const {
 
 describe(`Running tests for kono-api ${NODE_ENV} server.`, () => {
 
-    it('This test environment is not broken.', (done) => {
-        assert.equal(true, true, 'true should equal true');
-        done();
-    })
+    importTest('../routes.test');
+    importTest('../api/v1/post/post.test');
 
 });

--- a/kono-api/src/test/test.js
+++ b/kono-api/src/test/test.js
@@ -1,0 +1,23 @@
+import { assert } from 'chai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function importTest(path) {
+    describe(`Running unit tests in ${path}`, () => {
+        require(path);
+    });
+};
+
+const {
+    NODE_ENV
+} = process.env;
+
+describe(`Running tests for kono-api ${NODE_ENV} server.`, () => {
+
+    it('This test environment is not broken.', (done) => {
+        assert.equal(true, true, 'true should equal true');
+        done();
+    })
+
+});

--- a/kono-api/webpack.config.js
+++ b/kono-api/webpack.config.js
@@ -1,5 +1,3 @@
-var TerserPlugin = require('terser-webpack-plugin');
-
 module.exports = {
     mode: 'production',
     entry: './src/index.js',
@@ -11,15 +9,9 @@ module.exports = {
         rules: [
             {
                 test: /.js$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader'
-                }
+                exclude: /node_modules/
             }
         ]
     },
-    target: 'node',
-    optimization: {
-        minimizer: [new TerserPlugin({ terserOptions: { mangle: false } })]
-    }
+    target: 'node'
 }


### PR DESCRIPTION
테스트 환경을 조성하고 이미 만들어진 API에 대해 테스트 코드를 작성했다.
([Documentation](https://app.gitbook.com/@sparcs-kono/s/sparcs-kono/kono-api)에도 관련 정보가 올라갑니다)

### 테스트 환경 조성

- `mocha`, `chai` module 사용.
- `src/test/test.js`에 top level testing 코드 작성, 여기에서 `importTest` helper function으로 다른 테스트 파일들을 referencing함.
- development / production 서버가 동작하는 상태에서 `npm run test:dev`, `npm run test:production` npm script로 각 서버를 테스트 할 수 있음.
    - 이걸 지원하기 위해 `src/test/common.js`에서 환경변수를 읽어서 host name과 port를 세팅해 놓음. 

### 테스트 코드 작성

- API 테스트 코드는 API별 디렉토리 내에 라우팅 (`src/api/**/index.js`), 비즈니스 로직 (`src/api/**/<endpoint_name>.control.js`)에 추가로 테스트 코드를 `src/api/**/<endpoint_name>.test.js` 파일에 작성한다.
- `chai`의 `request`를 사용해서 서버에 HTTP call을 보내고 `chai.expect`로 assertion 하는 것이 convention이다.
- 정상적인 case와 error handling case에 대해 모두 테스트 케이스를 작성한다.
- Type checking과 value checking을 모두 작성한다.