### PR TITLE
Hotfix/adjust websocket proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,8 @@ services:
       WEBSOCKET_PORT: 7077
       HTTP_PORT: 7078
     build: kono-judge/
+    ports:
+      - "7077:7077"
     volumes:
       - judge:/usr/src/app
 

--- a/nginx-general/config/default.conf
+++ b/nginx-general/config/default.conf
@@ -10,10 +10,6 @@ upstream judge_http_server {
     server                  judge:7078;
 }
 
-upstream judge_ws_server {
-    server                  judge:7077;
-}
-
 server {
     listen			        80;
     server_name			    kono.sparcs.org;
@@ -33,20 +29,15 @@ server {
         proxy_set_header	Host $host;
         proxy_set_header	X-Real-IP $remote_addr;
         proxy_set_header	X-Forwarder-For $proxy_add_x_forwarded_for;
+	proxy_read_timeout	86400;
     }
 }
 
 server {
-    listen                  80;
-    server_name             judge.kono.sparcs.org;
-    location /ws {
-        proxy_pass          http://judge_ws_server;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-    }
+    listen                  	80;
+    server_name            	judge.kono.sparcs.org;
     location /{
-        proxy_pass          http://judge_http_server;
+        proxy_pass              http://judge_http_server;
         proxy_set_header	Host $host;
         proxy_set_header	X-Real-IP $remote_addr;
         proxy_set_header	X-Forwarder-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- Remove nginx reverse-proxying websocket server (`kono-judge`)
- Use separate port (7077) for websocket server
  - Browsers require true IP address for websocket connection, not DNS